### PR TITLE
Add `gitlab_branch` attribute.

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,10 @@ Attributes
   - Github gitlab address
   - Default git://github.com/gitlabhq/gitlabhq.git
 
+* gitlab['gitlab\_branch']
+  - Gitlab git branch
+  - Default master
+
 * gitlab['packages']
   - Platform specific OS packages
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -25,6 +25,7 @@ default['gitlab']['app_home'] = "#{node['gitlab']['home']}/gitlab"
 
 # Set github URL for gitlab
 default['gitlab']['gitlab_url'] = "git://github.com/gitlabhq/gitlabhq.git"
+default['gitlab']['gitlab_branch'] = "master"
 
 # Required packages for Gitlab
 case node['platform']

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -153,7 +153,7 @@ end
 # Clone Gitlab repo from github
 git node['gitlab']['app_home'] do
   repository node['gitlab']['gitlab_url']
-  reference "master"
+  reference node['gitlab']['gitlab_branch']
   action :checkout
   user node['gitlab']['user']
   group node['gitlab']['group']


### PR DESCRIPTION
Hey there,

This will allow a cookbook user to select which branch of the Git repo they desire. I left the default as `"master"` so as not to change any behavior, but I think a better default might be `"stable"` as they suggest in their [wiki page](https://github.com/gitlabhq/gitlabhq/wiki).
