### PR TITLE
Add pg libs

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -47,7 +47,7 @@ when "redhat","centos","amazon","scientific"
   when 6
     default['gitlab']['packages'] = %w{
       curl wget libxslt-devel sqlite-devel openssl-devel
-      mysql++-devel libicu-devel glibc-devel
+      mysql++-devel libicu-devel glibc-devel postgresql-devel
       libyaml-devel nginx python python-devel
     }
   end


### PR DESCRIPTION
On CentOS 6.3, needs yum package 'postgresql-devel' installed prior to bundle install.
