### PR TITLE
Don't build `pg` gem: fails when no postgres is installed; fixes #13

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -214,7 +214,7 @@ end
 
 # Install Gems with bundle install
 execute "gitlab-bundle-install" do
-  command "bundle install --without development test --deployment"
+  command "bundle install --without development test postgres --deployment"
   cwd node['gitlab']['app_home']
   user node['gitlab']['user']
   group node['gitlab']['group']


### PR DESCRIPTION
cfr https://github.com/atomic-penguin/cookbook-gitlab/issues/13
