### PR TITLE
Correct group ownership

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -97,6 +97,11 @@ group node['gitlab']['git_group'] do
   members node['gitlab']['user']
 end
 
+# Add the git user to the "gitlab" group
+group node['gitlab']['group'] do
+  members node['gitlab']['git_user']
+end
+
 # Create a $HOME/.ssh folder
 directory "#{node['gitlab']['home']}/.ssh" do
   owner node['gitlab']['user']


### PR DESCRIPTION
Switching protocols may "break" pushing to an existing gitlab repository. How to reproduce:
1. Clone an existing repo via "http(s)" protocol.
2. Change some file, commit an push. Everything ok so far.
3. Change the "protocol" to "git". (I mean doing this like: "git remote rm origin http://..." and "git remote add origin git://..."
4. Now change some files, commit an try to push again.
=> Now an error occurs: git complains that it's not allowed to read/write some objects in the remote repo.

Reason: When working with the git protocol, files are being updated by the git user. When working with the http(s) protocol, files are being updated by the gitlab user. If a repository has been modified using the gitlab user, then new files are being created for user:group gitlab:gitlab and user:group git:git doesn't have access to it.

Solution: Add the git user to the gitlab group in the default recipe. This is also part of the gitlab installation guide: https://github.com/gitlabhq/gitlabhq/blob/stable/doc/install/installation.md#3-users
