### PR TITLE
Install gitolite from gitlab's gitolite fork

### DIFF
--- a/attributes/gitolite.rb
+++ b/attributes/gitolite.rb
@@ -18,7 +18,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-default['gitlab']['gitolite_url'] = "git://github.com/sitaramc/gitolite.git"
+default['gitlab']['gitolite_url'] = "https://github.com/gitlabhq/gitolite.git"
+default['gitlab']['gitolite_branch'] = "gl-v304"
 default['gitlab']['git_user'] = "git"
 default['gitlab']['git_group'] = "git"
 

--- a/recipes/gitolite.rb
+++ b/recipes/gitolite.rb
@@ -54,7 +54,7 @@ end
 # Clone gitolite repo from github
 git node['gitlab']['gitolite_home'] do
   repository node['gitlab']['gitolite_url']
-  reference "master"
+  reference node['gitlab']['gitolite_branch']
   user node['gitlab']['git_user']
   group node['gitlab']['git_group']
   action :checkout


### PR DESCRIPTION
For me, installing gitlab on centos6 failed due to some perl packages missing when using the official gitolite master branch. Gitlab seems to have forked gitolite and recommends installing gitolite from their fork in v3.0.4 in their installation instructions: https://github.com/gitlabhq/gitlabhq/blob/stable/doc/install/installation.md#4-gitolite
Using their gitolite, installation succeeded on centos w/o any problems. Maybe it would be worth setting the url and branch they recommend as the default attributes.
