### PR TITLE
Fix bundle install's without_group always being set to mysql.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -241,7 +241,7 @@ template "#{node['gitlab']['app_home']}/config/database.yml" do
   )
 end
 
-without_group = node['gitlab']['database'] == 'mysql' ? 'postgres' : 'mysql'
+without_group = node['gitlab']['database']['type'] == 'mysql' ? 'postgres' : 'mysql'
 
 # Install Gems with bundle install
 execute "gitlab-bundle-install" do


### PR DESCRIPTION
GitLab's bundle install command was effectively hardcoded to `bundle install --without development test mysql --deployment` due to a miss in the without_group if condition.
