### PR TITLE
Fixes #37: yumrepo::epel doesn't exist anymore.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -25,11 +25,6 @@
   include_recipe requirement
 end
 
-case node['platform_family']
-when "rhel"
-  include_recipe "yumrepo::epel"
-end
-
 # symlink redis-cli into /usr/bin (needed for gitlab hooks to work)
 link "/usr/bin/redis-cli" do
   to "/usr/local/bin/redis-cli"


### PR DESCRIPTION
Fixes #37: yumrepo::epel doesn't exist anymore.
- Removed include_recipe for yumrepo:epel from default recipe.
  - yumrepo v2.0.0 doesn't use it anymore, since it is now in yum
    cookbook (commit 08024f5c665103566cfae6d016a1079c77c0a820 of
    yumrepo).
