### PR TITLE
fixed vagrant testing by moving up include_recipe block for database set...

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -2,9 +2,6 @@ site :opscode
 
 metadata
 
-# mysql::ruby dependency seems to bypass this.
-# manual `apt-get update` may be necessary to
-# converge on test-kitchen despite this dependency.
 group :integration do
   cookbook 'apt', '~> 2.0'
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -25,6 +25,17 @@ when 'rhel'
   include_recipe 'yum::epel'
 end
 
+
+# Setup the database
+case node['gitlab']['database']['type']
+  when 'mysql'
+    include_recipe 'gitlab::mysql'
+  when 'postgres'
+    include_recipe 'gitlab::postgres'
+  else
+    Chef::Log.error "#{node['gitlab']['database']['type']} is not a valid type. Please use 'mysql' or 'postgres'!"
+end
+
 # Install the required packages via cookbook
 node['gitlab']['cookbook_dependencies'].each do |requirement|  
   include_recipe requirement
@@ -138,17 +149,6 @@ git node['gitlab']['app_home'] do
   action :checkout
   user node['gitlab']['user']
   group node['gitlab']['group']
-end
-
-
-# Setup the database
-case node['gitlab']['database']['type']
-  when 'mysql'
-    include_recipe 'gitlab::mysql'
-  when 'postgres'
-    include_recipe 'gitlab::postgres'
-  else
-    Chef::Log.error "#{node['gitlab']['database']['type']} is not a valid type. Please use 'mysql' or 'postgres'!"
 end
 
 # Write the database.yml


### PR DESCRIPTION
...up

Seems not to be an issue with mysql::ruby.

Tried a test with current ruby cookbook and included mysql::ruby there. Works.

Now i found out testing works when providing the inclusion above in gitlabs default.rb 

Seems to be an issue with some of the providers used before (??). Or some parallel thing in the new chef 11.

The apt-get update running is NOT caused by apt cookbook, it is build-esssential for me, that updates in the mentioned fix.
