### PR TITLE
Updated satellites path to fix Gitlab forking

### DIFF
--- a/templates/default/gitlab.yml.erb
+++ b/templates/default/gitlab.yml.erb
@@ -144,7 +144,7 @@ production: &base
   # GitLab Satellites
   satellites:
     # Relative paths are relative to Rails.root (default: tmp/repo_satellites/)
-    path: /home/git/gitlab-satellites/
+    path: <%= @git_home %>/gitlab-satellites/
 
   ## Backup settings
   backup:


### PR DESCRIPTION
Gitlab forking was broken because the default path for satellites was incorrect (at least on Ubuntu). I updated the configuration to use the @git_home variable.
