### PR TITLE
Added support for enabling/disabling Gravatar

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,11 @@ Attributes
     See [nginx server_name documentation](http://nginx.org/en/docs/http/server_names.html)
     for valid matching patterns.
 
+* gitlab['gravatar']['enabled']
+  - Use Gravatar to fetch user avatars 
+  - Options: "true", "false"
+  - Default "true"
+
 ### Database Attributes
 
 **Note**, most of the database attributes have sane defaults. You will only need to change these configuration options if

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -92,3 +92,6 @@ default['gitlab']['backup_keep_time'] = 604800
 # Ip and port nginx will be serving requests on
 default['gitlab']['listen_ip'] = "*"
 default['gitlab']['listen_port'] = nil
+
+# Gravatar
+default['gitlab']['gravatar']['enabled'] = true 

--- a/templates/default/gitlab.yml.erb
+++ b/templates/default/gitlab.yml.erb
@@ -88,7 +88,7 @@ production: &base
 
   ## Gravatar
   gravatar:
-    enabled: true                 # Use user avatar image from Gravatar.com (default: true)
+    enabled: <%= node['gitlab']['gravatar']['enabled'] %> # Use user avatar image from Gravatar.com (default: true)
     # plain_url: "http://..."     # default: http://www.gravatar.com/avatar/%{hash}?s=%{size}&d=mm
     # ssl_url:   "https://..."    # default: https://secure.gravatar.com/avatar/%{hash}?s=%{size}&d=mm
 


### PR DESCRIPTION
Support for enabling/disabling Gravatar was missing from templates/default/gitlab.yml.erb so I added it. I also updated the documentation with the new attribute.
