### PR TITLE
Hardened bundler usage slightly

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -342,6 +342,7 @@ end
 
 # Enable and start unicorn and sidekiq service
 service 'gitlab' do
+  pattern "unicorn_rails master -D -c #{node['gitlab']['app_home']}/config/unicorn.rb"
   action [:enable, :start]
   subscribes :restart, "template[#{node['gitlab']['app_home']}/config/gitlab.yml]", :delayed
 end

--- a/templates/default/gitlab.init.erb
+++ b/templates/default/gitlab.init.erb
@@ -168,14 +168,14 @@ start() {
     # Remove old socket if it exists
     rm -f "$socket_path"/gitlab.socket 2>/dev/null
     # Start the web server
-    RAILS_ENV=$RAILS_ENV script/web start &
+    RAILS_ENV=$RAILS_ENV script/web start
   fi
 
   # If sidekiq is already running, don't start it again.
   if [ "$sidekiq_status" = "0" ]; then
     echo "The Sidekiq job dispatcher is already running with pid $spid, not restarting"
   else
-    RAILS_ENV=$RAILS_ENV script/background_jobs start &
+    RAILS_ENV=$RAILS_ENV script/background_jobs start
   fi
 
   # Wait for the pids to be planted


### PR DESCRIPTION
First off, thanks for this cookbook!

I had issues getting the default recipe to converge on chef 11.8.2. It seems that if bundler is installed in chef's embedded ruby, the calls to bundle will use that binary instead of the ruby that was built via the default recipe. This pull request passes the absolute path to the installed ruby bundler binary. I also extended the bundler deployment install to drop a file on success only. If that bundle install command failed partway through but was able to create the `vendor/bundle` directory, the bundle would not run again and therefore the deployment install would not be finished.

```

[2014-01-20T04:26:17+00:00] INFO: directory[/srv/git/gitlab/public/uploads] mode changed to 755       

    - change mode from '' to '0755'       
           - change owner from '' to 'git'
           - change group from '' to 'git'

         * execute[gitlab-bundle-precompile-assets] action run
[2014-01-20T04:26:17+00:00] INFO: Processing execute[gitlab-bundle-precompile-assets] action run (gitlab::default line 209)       

================================================================================       
Error executing action `run` on resource 'execute[gitlab-bundle-precompile-assets]'       
================================================================================       


Mixlib::ShellOut::ShellCommandFailed       
------------------------------------       
Expected process to exit with [0], but received '1'       
---- Begin output of bundle exec rake assets:precompile RAILS_ENV=production ----       
STDOUT:        
       STDERR: /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/bundler-1.1.5/lib/bundler/spec_set.rb:90:in `block in materialize': Could not find i18n-0.6.9 in any of the sources (Bundler::GemNotFound)
        from /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/bundler-1.1.5/lib/bundler/spec_set.rb:83:in `map!'
        from /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/bundler-1.1.5/lib/bundler/spec_set.rb:83:in `materialize'
        from /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/bundler-1.1.5/lib/bundler/definition.rb:127:in `specs'
        from /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/bundler-1.1.5/lib/bundler/definition.rb:172:in `specs_for'
        from /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/bundler-1.1.5/lib/bundler/definition.rb:161:in `requested_specs'
        from /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/bundler-1.1.5/lib/bundler/environment.rb:23:in `requested_specs'
        from /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/bundler-1.1.5/lib/bundler/runtime.rb:11:in `setup'
        from /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/bundler-1.1.5/lib/bundler.rb:107:in `setup'
        from /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/bundler-1.1.5/lib/bundler/setup.rb:17:in `<top (required)>'
        from /opt/chef/embedded/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
        from /opt/chef/embedded/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
       ---- End output of bundle exec rake assets:precompile RAILS_ENV=production ----
       Ran bundle exec rake assets:precompile RAILS_ENV=production returned 1


       Resource Declaration:
       ---------------------
       # In /tmp/kitchen/cookbooks/gitlab/recipes/default.rb

       209: execute 'gitlab-bundle-precompile-assets' do
       210:   command 'bundle exec rake assets:precompile RAILS_ENV=production'
       211:   cwd node['gitlab']['app_home']
       212:   user node['gitlab']['user']
       213:   group node['gitlab']['group']
       214:   environment('LANG' => 'en_US.UTF-8', 'LC_ALL' => 'en_US.UTF-8')
       215:   only_if { Dir["#{node['gitlab']['app_home']}/public/assets/*"].empty? }
       216: end
       217: 



       Compiled Resource:

       ------------------
       # Declared in /tmp/kitchen/cookbooks/gitlab/recipes/default.rb:209:in `from_file'

       execute("gitlab-bundle-precompile-assets") do
         action "run"
         retries 0
         retry_delay 2
         command "bundle exec rake assets:precompile RAILS_ENV=production"
         backup 5
         cwd "/srv/git/gitlab"
         environment {"LANG"=>"en_US.UTF-8", "LC_ALL"=>"en_US.UTF-8"}
         group "git"
         returns 0
         user "git"
         cookbook_name :gitlab
         recipe_name "default"
         only_if { #code block }
       end



       [2014-01-20T04:26:18+00:00] INFO: Running queued delayed notifications before re-raising exception

       [2014-01-20T04:26:18+00:00] INFO: template[/etc/mysql/debian.cnf] sending reload action to service[mysql] (delayed)

       Recipe: mysql::_server_debian
         * service[mysql] action reload
[2014-01-20T04:26:18+00:00] INFO: Processing service[mysql] action reload (mysql::_server_debian line 126)       
       [2014-01-20T04:26:18+00:00] INFO: service[mysql] reloaded

           - reload service service[mysql]

       [2014-01-20T04:26:18+00:00] INFO: template[/etc/ssh/sshd_config] sending restart action to service[ssh] (delayed)
       Recipe: openssh::default
         * service[ssh] action restart[2014-01-20T04:26:18+00:00] INFO: Processing service[ssh] action restart (openssh::default line 32)
       [2014-01-20T04:26:18+00:00] INFO: service[ssh] restarted

           - restart service service[ssh]

       [2014-01-20T04:26:18+00:00] INFO: [template[/srv/git/gitlab/config/gitlab.yml]] sending restart action to service[gitlab] (delayed)
       Recipe: gitlab::default
         * service[gitlab] action restart
[2014-01-20T04:26:18+00:00] INFO: Processing service[gitlab] action restart (gitlab::default line 341)       

================================================================================       
Error executing action `restart` on resource 'service[gitlab]'       
================================================================================       


Errno::ENOENT       
-------------       
No such file or directory - /etc/init.d/gitlab stop       


Resource Declaration:       
---------------------       
# In /tmp/kitchen/cookbooks/gitlab/recipes/default.rb       

       341: service 'gitlab' do
       342:   action [:enable, :start]
       343:   subscribes :restart, "template[#{node['gitlab']['app_home']}/config/gitlab.yml]", :delayed
       344: end



       Compiled Resource:
       ------------------
       # Declared in /tmp/kitchen/cookbooks/gitlab/recipes/default.rb:341:in `from_file'

       service("gitlab") do
         action [:enable, :start]
         supports {:restart=>false, :reload=>false, :status=>false}
         retries 0
         retry_delay 2
         service_name "gitlab"
         pattern "gitlab"
         startup_type :automatic
         cookbook_name :gitlab
         recipe_name "default"
       end



       [2014-01-20T04:26:18+00:00] ERROR: Running exception handlers

[2014-01-20T04:26:18+00:00] ERROR: Exception handlers complete       
[2014-01-20T04:26:18+00:00] FATAL: Stacktrace dumped to /tmp/kitchen/cache/chef-stacktrace.out       
Chef Client failed. 89 resources updated       
[2014-01-20T04:26:18+00:00] ERROR: Chef::Exceptions::MultipleFailures       
[2014-01-20T04:26:18+00:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)       
>>>>>> Converge failed on instance <default-ubuntu-1304>.
>>>>>> Please see .kitchen/logs/default-ubuntu-1304.log for more details
>>>>>> ------Exception-------
>>>>>> Class: Kitchen::ActionFailed
>>>>>> Message: SSH exited (1) for command: [sudo -E chef-solo --config /tmp/kitchen/solo.rb --json-attributes /tmp/kitchen/dna.json  --log_level info]
```
