### PR TITLE
New runner and docker recipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,10 @@ Recipes
 
 This installs and starts GitLab with nginx and your chosen database.
 
+## runner
+
+This installs GitLab Runner. This does not have to be on the same system, in fact GitLab recommend against it.
+
 ## mysql, postgres
 
 These are internal, set `gitlab['database']['type']` instead.

--- a/README.md
+++ b/README.md
@@ -245,6 +245,10 @@ This installs and starts GitLab with nginx and your chosen database.
 
 This installs GitLab Runner. This does not have to be on the same system, in fact GitLab recommend against it.
 
+## docker
+
+This installs Docker and starts the service. It includes the `runner` recipe above.
+
 ## mysql, postgres
 
 These are internal, set `gitlab['database']['type']` instead.

--- a/README.md
+++ b/README.md
@@ -234,6 +234,17 @@ is calculated.
   - You can provide a query string here to filter which users will be selected
   - Default: ""
 
+Recipes
+=======
+
+## default
+
+This installs and starts GitLab with nginx and your chosen database.
+
+## mysql, postgres
+
+These are internal, set `gitlab['database']['type']` instead.
+
 Usage
 =====
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -31,6 +31,7 @@ source_url 'https://github.com/atomic-penguin/cookbook-gitlab'
   depends cb_depend
 end
 depends 'chef_nginx', '~> 5.1'
+depends 'docker', '~> 2.0'
 depends 'mysql', '~> 6.0'
 depends 'mysql2_chef_gem'
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -18,6 +18,7 @@ source_url 'https://github.com/atomic-penguin/cookbook-gitlab'
   ncurses
   nodejs
   openssh
+  packagecloud
   postgresql
   readline
   redisio

--- a/recipes/docker.rb
+++ b/recipes/docker.rb
@@ -1,0 +1,30 @@
+#
+# Cookbook Name:: gitlab
+# Recipe:: docker
+#
+# Copyright 2016, Yakara Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include_recipe 'gitlab::runner'
+
+docker_service 'default' do
+  action [:create, :start]
+end
+
+group 'docker' do
+  members 'gitlab-runner'
+  append true
+  action :modify
+end

--- a/recipes/runner.rb
+++ b/recipes/runner.rb
@@ -1,0 +1,24 @@
+#
+# Cookbook Name:: gitlab
+# Recipe:: runner
+#
+# Copyright 2016, Yakara Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+packagecloud_repo 'runner/gitlab-ci-multi-runner' do
+  base_url 'https://packages.gitlab.com'
+end
+
+package 'gitlab-ci-multi-runner'


### PR DESCRIPTION
We're setting up some CI stuff here. We haven't put it into production yet but thought I'd put this out there now anyhow. There's a lot less to these recipes than I thought there would be, thanks largely to the packagecloud and docker cookbooks.

We're using docker-compose as well but I gather that isn't the standard approach under GitLab CI and our own recipe for installing that does nothing GitLab-related anyway.
